### PR TITLE
🐛 Fix: 모달/메뉴 활성화 시 스크롤 고정

### DIFF
--- a/src/components/layouts/aside/AsideMobile.jsx
+++ b/src/components/layouts/aside/AsideMobile.jsx
@@ -1,12 +1,15 @@
-import BtnIcon from '@/components/common/button/BtnIcon';
 import { useEffect, useRef, useState } from 'react';
+
+import classNames from 'classnames';
+
+import styles from './AsideMobile.module.scss';
+
+import { handleAllowScroll, handlePreventScroll } from '@/utils/handleScroll';
+
 import Toc from './Toc';
 import SubBanner from './SubBanner';
 import SVGUpArrow from '@/components/svg/SVGUpArrow';
-
-import styles from './AsideMobile.module.scss';
 import SVGDownArrow from '@/components/svg/SVGDownArrow';
-import classNames from 'classnames';
 
 export default function AsideMobile() {
   const [clicked, setClicked] = useState(false);
@@ -36,9 +39,12 @@ export default function AsideMobile() {
     !clicked && setClicked(true);
     setIsMenuShow((prev) => !prev);
     if (!isMenuShow) {
+      handlePreventScroll();
       setTimeout(() => {
         lastBtn.current.focus();
       }, 100);
+    } else {
+      handleAllowScroll();
     }
   };
 

--- a/src/components/layouts/menu/Side.jsx
+++ b/src/components/layouts/menu/Side.jsx
@@ -1,24 +1,30 @@
 'use client';
+import { useContext, useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+import classNames from 'classnames';
+
 import styles from './Side.module.scss';
 
-import { useContext, useEffect, useRef, useState } from 'react';
+import { SettingContext } from '@/context/SettingContext';
 
 import useWindowSize from '@/utils/useWindowSize';
-import { SettingContext } from '@/context/SettingContext';
+import { handleAllowScroll, handlePreventScroll } from '@/utils/handleScroll';
+
 import Nav from './Nav';
 import BtnIcon from '../../common/button/BtnIcon';
 import Footer from '../footer/Footer';
 import SVGList from '../../svg/SVGList';
-import classNames from 'classnames';
 import SVGListClose from '../../svg/SVGListClose';
-import { usePathname } from 'next/navigation';
 
 export default function Side(props) {
   const path = usePathname();
 
   const { windowWidth } = useWindowSize();
   const { isSavedClose, setIsSavedClose } = useContext(SettingContext);
-  const [isShowMenu, setIsShowMenu] = useState(isSavedClose ? false : true);
+  const [isMenuShow, setIsMenuShow] = useState(
+    isSavedClose ? false : windowWidth < 1024 ? false : true,
+  );
   const slideRef = useRef(null);
 
   const handleFocusFirst = (e) => {
@@ -41,11 +47,12 @@ export default function Side(props) {
   };
 
   const toggleMenu = () => {
-    if (isShowMenu) {
+    if (isMenuShow) {
       // SlideOut(닫힘)
       slideRef.current.classList.add(styles.slideOut);
+      handleAllowScroll();
       setTimeout(() => {
-        setIsShowMenu(false);
+        setIsMenuShow(false);
         if (windowWidth > 1024) {
           localStorage.setItem('menu', 'close');
           setIsSavedClose(true);
@@ -53,35 +60,43 @@ export default function Side(props) {
       }, 300);
     } else {
       // SlideIn(열림)
-      setIsShowMenu(true);
+      setIsMenuShow(true);
+      handlePreventScroll();
       setTimeout(() => {
         slideRef.current.classList.add(styles.slideIn);
 
         const firstItem = slideRef.current.querySelector('a, button');
-        firstItem.focus();
+        if (firstItem) {
+          firstItem.focus();
+        }
 
         if (windowWidth > 1024) {
           localStorage.removeItem('menu');
           setIsSavedClose(false);
         }
-      }, 0);
+      }, 100);
     }
   };
 
   useEffect(() => {
     if (windowWidth !== null && windowWidth <= 1024) {
       // 모바일
-      setIsShowMenu(false);
+      setIsMenuShow(false);
     } else {
       // PC
-      setIsShowMenu(isSavedClose ? false : true);
+      setIsMenuShow(isSavedClose ? false : true);
     }
   }, [windowWidth, path]);
 
   useEffect(() => {
+    document.body.removeAttribute('style');
+    window.scrollTo(0, 0);
+  }, [path]);
+
+  useEffect(() => {
     const handleOutsideClick = (e) => {
       if (!slideRef.current.contains(e.target)) {
-        setIsShowMenu(false);
+        toggleMenu();
       }
     };
     const handleESC = (e) => {
@@ -90,7 +105,7 @@ export default function Side(props) {
       }
     };
 
-    if (isShowMenu && windowWidth !== null && windowWidth < 1024) {
+    if (isMenuShow && windowWidth !== null && windowWidth < 1024) {
       setTimeout(() => {
         window.addEventListener('click', handleOutsideClick);
         window.addEventListener('keydown', handleESC);
@@ -104,15 +119,15 @@ export default function Side(props) {
       window.removeEventListener('click', handleOutsideClick);
       window.removeEventListener('keydown', handleESC);
     };
-  }, [isShowMenu]);
+  }, [isMenuShow]);
 
   return (
     <>
-      {isShowMenu && (
+      {isMenuShow && (
         <>
           <div ref={slideRef} className={classNames(styles.side)}>
             <Nav {...props} />
-            <Footer />
+            {windowWidth !== null && windowWidth >= 1024 && <Footer />}
             <BtnIcon
               className={styles.btnClose}
               children={<SVGListClose color="grayLv3" />}
@@ -132,10 +147,10 @@ export default function Side(props) {
         type="button"
         className={classNames(
           styles.btnOpen,
-          isShowMenu ? styles.hide : styles.show,
+          isMenuShow ? styles.hide : styles.show,
         )}
         onClick={toggleMenu}
-        disabled={isShowMenu ? true : false}
+        disabled={isMenuShow ? true : false}
       >
         <SVGList color="grayLv3" />
         <span className="a11y-hidden">메뉴 열기</span>

--- a/src/components/layouts/menu/Side.module.scss
+++ b/src/components/layouts/menu/Side.module.scss
@@ -30,6 +30,7 @@
     top: 0;
     margin-left: -32rem;
     height: 100vh;
+    height: -webkit-fill-available;
     z-index: 2000;
 
     & + [class~='dim'] {

--- a/src/components/setting/SettingBtn.jsx
+++ b/src/components/setting/SettingBtn.jsx
@@ -7,6 +7,7 @@ import styles from './SettingBtn.module.scss';
 import SettingModal from './SettingModal';
 import classNames from 'classnames';
 import { usePathname } from 'next/navigation';
+import { handleAllowScroll, handlePreventScroll } from '@/utils/handleScroll';
 
 export default function SettingBtn() {
   const [isOpen, setIsOpen] = useState(false);
@@ -14,20 +15,14 @@ export default function SettingBtn() {
   const pathname = usePathname();
 
   const handleToggle = () => {
-    setIsOpen(!isOpen);
-  };
-
-  useEffect(() => {
     if (isOpen) {
-      document.body.style.cssText = `
-      overflow: hidden;
-      position: relative;
-      height: 100%;`;
+      setIsOpen(false);
+      handleAllowScroll();
+    } else {
+      setIsOpen(true);
+      handlePreventScroll();
     }
-    return () => {
-      document.body.removeAttribute('style');
-    };
-  }, [isOpen]);
+  };
 
   useEffect(() => {
     if (isOpen) {
@@ -53,7 +48,7 @@ export default function SettingBtn() {
           !modalRef.current.contains(e.target) ||
           e.target.dataset.dim === 'dim'
         ) {
-          setIsOpen(false);
+          handleToggle();
         }
       };
       const handleESC = (e) => {

--- a/src/utils/handleScroll.js
+++ b/src/utils/handleScroll.js
@@ -1,0 +1,19 @@
+let prevScrollY;
+
+export const handlePreventScroll = () => {
+  prevScrollY = window.scrollY;
+
+  setTimeout(() => {
+    document.body.style.cssText = `
+  position: fixed;
+  width: 100%;
+  top: -${prevScrollY}px;
+  overflow-y: scroll;
+`;
+  }, 100);
+};
+
+export const handleAllowScroll = (scrollY) => {
+  document.body.removeAttribute('style');
+  window.scrollTo(0, scrollY ? scrollY : prevScrollY);
+};


### PR DESCRIPTION
# 📝 PR: 모달/메뉴 활성화 시 스크롤 고정

## ✏️ 요약
- 모달/메뉴 활성화 시 스크롤 고정

## 👩‍💻 작업내용
<!-- 새로운 기능의 추가나 데이터 처리의 경우 코드단위로의 설명해 주세요 -->
- 모달, 메뉴 활성화 시 뒷 컨텐츠의 스크롤이 움직임. 접근성 고려하여 스크롤 고정 처리
- 설정 모달(PC/Mobile) / 전체 메뉴(Mobile) / 목차 메뉴(Mobile)
  - 활성화시 스크롤 고정
  - 비활성화시 스크롤 고정 해제

## ✅ 체크리스트

### [UI] 화면에 잘 나오는가
<!-- 해당 작업이 PC/Mobile 반응형으로 잘 나오고 있는지 체크해주세요! 
  추후 작업 예정이라면 이슈를 생성해서 관리해주세요! -->
- [x]  PC
- [x]  Mobile

### [Feat] 잘 동작하는가
<!-- 해당 기능에 대해서 테스트 해주세요. 스크린샷, gif 등을 첨부하셔도 좋습니다.-->
- [x] PC/Mobile 설정 모달 활성화/비활성화 스크롤 고정/해제
- [x] Mobile 전체메뉴 활성화/비활성화 스크롤 고정/해제
- [x] Mobile 목차메뉴 활성화/비활성화 스크롤 고정/해제